### PR TITLE
corrige papel de atuação nna minha bio

### DIFF
--- a/Guia-ODD/Guia-ODD2020.md
+++ b/Guia-ODD/Guia-ODD2020.md
@@ -125,7 +125,7 @@ Sem roteiro fechado, os participantes discutiram ideias, dividiram-se em dois gr
 ---
 \*Participaram da live, contribuindo imensamente para enriquecer os preparativos para o __#ODD2020__, as seguintes pessoas:
 - [Fernanda Campagnucci](https://twitter.com/fecampa), diretora-executiva da Open Knowledge Brasil
--   Augusto Herrmann Batista: Analista em TI no Ministério da Economia — deu início à política de dados abertos no governo federal brasileiro, onde foi desenvolvedor durante 8 anos. _É colaborador da Open Knowledge e responsável por fazer a versão brasileira do site do_ [_Open Data Day_](https://opendataday.org/pt_br/)
+-   Augusto Herrmann Batista: Analista em TI no Ministério da Economia — deu início à política de dados abertos no governo federal brasileiro, onde atuou na sua gestão e implementação durante 8 anos. _É colaborador da Open Knowledge e responsável por fazer a versão brasileira do site do_ [_Open Data Day_](https://opendataday.org/pt_br/)
 -   [Juliana Trevine](https://twitter.com/_jtrevine): Graduanda no IME e com o coração dedicado ao Grupo de Computação Social da USP (Tecs). _Integra a rede de pessoas Embaixadoras de Inovação Cívica_
 -   [Thays Lavor](https://twitter.com/thayslavor): jornalista que atua como freelancer para veículos nacionais e internacionais, trabalha com jornalismo investigativo e de dados. _Integra a rede de pessoas Embaixadoras de Inovação Cívica, além de ser membro da Escola de Dados_
  

--- a/_posts/2020-01-21-live-open-data-day-2020.md
+++ b/_posts/2020-01-21-live-open-data-day-2020.md
@@ -13,7 +13,7 @@ A conversa foi tão valiosa que gerou um documento, o [Guia Embaixadoras para o 
 
 Com mediação de [Mário Sérgio](https://twitter.com/sergiomarioq){:target="_blank"} e [Fernanda Campagnucci](https://twitter.com/fecampa){:target="_blank"}, a primeira live do ano teve excelentes participações:
 
--   Augusto Herrmann Batista: Analista em TI no Ministério da Economia — deu início à política de dados abertos no governo federal brasileiro, onde foi desenvolvedor durante 8 anos. _É colaborador da Open Knowledge e responsável por fazer a versão brasileira do site do_ [_Open Data Day_](https://opendataday.org/pt_br/){:target="_blank"}.
+-   Augusto Herrmann Batista: Analista em TI no Ministério da Economia — deu início à política de dados abertos no governo federal brasileiro, onde atuou na sua gestão e implementação durante 8 anos. _É colaborador da Open Knowledge e responsável por fazer a versão brasileira do site do_ [_Open Data Day_](https://opendataday.org/pt_br/){:target="_blank"}.
 
 -   [Juliana Trevine](https://twitter.com/_jtrevine){:target="_blank"}: Graduanda no IME e com o coração dedicado ao Grupo de Computação Social da USP (Tecs). _Integra a rede de pessoas Embaixadoras de Inovação Cívica_.
 


### PR DESCRIPTION
Corrigindo minha bio. Atuei como desenvolvedor apenas em pequenos momentos específicos no tempo. A maior parte do tempo foi na gestão e implementação da política de dados abertos.