### PR TITLE
Ignora os arquivos de configuração do VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+.vscode/


### PR DESCRIPTION
para quem usa VSCode/VSCodium, é conveniente que a pasta de configuração
do *workspace* seja ignorada. Assim ela não aparecerá entre os arquivos
modificados, já que é uma configuração local de cada pessoa desenvolvedora
e não será enviada ao repositório.